### PR TITLE
Make header backgrounds translucent

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -113,12 +113,18 @@ section {
     position: sticky;
     top: 0;
     z-index: 1000;
-    background: var(--white);
+    background: transparent;
+    background-color: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
     box-shadow: 0 12px 32px -20px rgba(10, 46, 109, 0.45);
 }
 
 .utility-bar {
-    background: var(--white);
+    background: transparent;
+    background-color: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
     border-bottom: 1px solid rgba(12, 44, 102, 0.08);
 }
 


### PR DESCRIPTION
## Summary
- make the sticky site header and utility bar backgrounds translucent instead of opaque white
- add a blurred translucent fallback to keep header text readable while allowing page gradients to show through the logo

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ded6fda4688330b42af95ce9bc6594