### PR TITLE
Relax header overlay

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -114,7 +114,7 @@ section {
     top: 0;
     z-index: 1000;
     background: transparent;
-    background-color: rgba(255, 255, 255, 0.85);
+    background-color: rgba(255, 255, 255, 0.32);
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
     box-shadow: 0 12px 32px -20px rgba(10, 46, 109, 0.45);
@@ -122,7 +122,7 @@ section {
 
 .utility-bar {
     background: transparent;
-    background-color: rgba(255, 255, 255, 0.85);
+    background-color: rgba(255, 255, 255, 0.24);
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
     border-bottom: 1px solid rgba(12, 44, 102, 0.08);
@@ -140,6 +140,7 @@ section {
     align-items: center;
     position: relative;
     text-decoration: none;
+    isolation: isolate;
 }
 
 .logo-mark {


### PR DESCRIPTION
## Summary
- dial back the translucent white overlays on the header and utility bar so the hero gradient shows through the logo area
- ensure the logo stack renders independently to avoid the backdrop smearing into it

## Testing
- Manual verification by serving the static site with `python3 -m http.server 8000` and spot-checking the home page

------
https://chatgpt.com/codex/tasks/task_e_68dee7658fb483308a6e89e168c725b1